### PR TITLE
Extract domain logic in entity Workday

### DIFF
--- a/src/app/core/domain/entity.class.ts
+++ b/src/app/core/domain/entity.class.ts
@@ -1,0 +1,33 @@
+const isEntity = (v: unknown): v is Entity<unknown> => {
+  return v instanceof Entity;
+};
+
+export abstract class Entity<T> {
+  protected readonly _id: string | null;
+  protected props: T;
+
+  constructor(props: T, id?: string) {
+    this._id = id || null;
+    this.props = props;
+  }
+
+  isEmpty() {
+    return this._id === null;
+  }
+
+  equals(object: Entity<T>): boolean {
+    if (object == null || object == undefined) {
+      return false;
+    }
+
+    if (this === object) {
+      return true;
+    }
+
+    if (!isEntity(object)) {
+      return false;
+    }
+
+    return this._id === object._id;
+  }
+}

--- a/src/app/core/entity/workday.spec.ts
+++ b/src/app/core/entity/workday.spec.ts
@@ -1,0 +1,7 @@
+import { Workday } from './workday';
+
+describe('Workday', () => {
+  it('should create an instance', () => {
+    expect(Workday.createEmpty()).toBeTruthy();
+  });
+});

--- a/src/app/core/entity/workday.ts
+++ b/src/app/core/entity/workday.ts
@@ -1,0 +1,220 @@
+// Modélisation de la couche métier - Entité Workday
+import {
+  getActivePomodoroIndex,
+  getActiveTask,
+  getActiveTaskIndex,
+  getTaskEmojiStatus,
+  isTaskCompleted,
+  Task,
+  TaskList,
+} from '@app/membership/workday/task.model';
+import { Entity } from '../domain/entity.class';
+
+// Contrat de structure de données pour l'objet 'Workday' (WorkdayProps)
+interface WorkdayProps {
+  taskList: TaskList;
+  mode: 'edit' | 'execution';
+}
+
+export class Workday extends Entity<WorkdayProps> {
+  // Constantes métier
+  static readonly MAX_POMODORO_DURATION_IN_SEC = 5; // Durée maximum d'un pomodoro en secondes (5 secondes pour les tests, 1500 secondes pour 25 minutes)
+  static readonly MAX_TASKS_PER_DAY = 6; // Nombre maximum de tâches par journée de travail
+  override readonly _id;
+
+  // Constructeur privé pour forcer l'utilisation des Factory Methods
+  // Pour instancier une journée de travail avec des propriétés spécifiques (workday props) et une date (id unique)
+  private constructor(props: WorkdayProps, date: string) {
+    super(props, date);
+    this._id = date;
+  }
+
+  // ** Factory Methods ** // 
+
+  // Méthode statique pour créer une journée de travail vide
+  static createEmpty(): Workday {
+    // Utilisation du timestamp actuel comme identifiant unique
+    const date = Date.now(); 
+    // Génération des propriétés par défaut
+    const taskList: TaskList = [
+      {
+        type: 'Hit the target',
+        title: 'Nouvelle tâche',
+        status: 'Not started',
+        pomodoroCount: 1,
+        pomodoroList: [0],
+        statusEmoji: '🏁',
+      },
+    ];
+    const mode = 'edit';
+    const emptyProps: WorkdayProps = { taskList, mode };
+
+    // Retourne une nouvelle instance de Workday avec les propriétés par défaut et la date actuelle en faisant appel au constructeur privé (instanciation à l'intérieur de la classe uniquement)
+    return new Workday(emptyProps, date.toString()); // Conversion du timestamp en chaîne de caractères pour l'identifiant
+  }
+
+  // Méthode pour créer une journée de travail vide à une date spécifique
+  createEmptyAtDate(date: string): Workday {
+    const workday = Workday.createEmpty();
+    return new Workday(workday.props, date);
+  }
+
+  /** Readonly - Getters qui retournent la valeur des propriétés de l'entité Workday  **/
+
+  // Retourne la date associée à la journée de travail - Attribution d'un identifiant unique à chaque journée
+  get date(): string {
+    return this._id;
+  }
+
+  // Retourne la liste des tâches planifiées pour la journée
+  get taskList(): TaskList {
+    return this.props.taskList;
+  }
+
+  // Retourne le nombre de tâches planifiées pour la journée
+  get taskCount(): number {
+    return this.props.taskList.length;
+  }
+
+  // Retourne vrai si au moins une tâche est planifiée pour la journée
+  get hasTaskPlanned(): boolean {
+    return this.taskCount > 0;
+  }
+
+  // Retourne vrai si aucune tâche n'est planifiée pour la journée
+  get hasNoTaskPlanned(): boolean {
+    return this.taskCount === 0;
+  }
+
+  // Retourne vrai si le mode actuel est le mode édition
+  get isEditMode(): boolean {
+    return this.props.mode === 'edit';
+  }
+
+  // Retourne vrai si le mode actuel est le mode exécution
+  get isExecutionMode(): boolean {
+    return this.props.mode === 'execution';
+  }
+ // Retourne vrai si toutes les tâches de la journée sont complétées
+  get isWorkdayCompleted(): boolean {
+    return this.taskList.every((task) => {
+      return isTaskCompleted(task);
+    });
+  }
+
+  // Retourne vrai si une nouvelle tâche peut être ajoutée (limite maximale non atteinte)
+  get canAddTask(): boolean {
+    return this.taskCount < Workday.MAX_TASKS_PER_DAY;
+  }
+
+ 
+  //** Méthodes d'action pour modifier l'état de l'entité Workday - Setters **//
+
+  // Passage au mode exécution
+  setExecutionMode(): Workday {
+    if (this.isExecutionMode) {
+      throw new Error('Workday is already in execution mode.');
+    }
+    this.props.mode = 'execution';
+    return this;
+  }
+
+  // Passage au mode édition
+  setEditMode(): Workday {
+    if (this.isEditMode) {
+      throw new Error('Workday is already in edit mode.');
+    }
+    this.props.mode = 'edit';
+    return this;
+  }
+
+  // Ajout d'une nouvelle tâche vide à la journée de travail
+  addEmptyTask(): Workday {
+    if (this.taskCount >= Workday.MAX_TASKS_PER_DAY) {
+      throw new Error('Maximum number of tasks reached for the day.');
+    }
+    this.props.taskList.push(Workday.getEmptyTask());
+    return this;
+  }
+
+  // Mise à jour d'une tâche existante à la journée de travail
+  updateTask(index: number, updatedTask: Task): Workday {
+    if (index < 0 || index >= this.props.taskList.length) {
+      throw new Error(`Cannot update task at index ${index}.`);
+    }
+    this.props.taskList[index] = updatedTask;
+    return this;
+  }
+
+  // Suppression d'une tâche existante de la journée de travail
+  removeTask(index: number): Workday {
+    // Vérification de la validité de l'index de la tâche à supprimer
+    if (index < 0 || index >= this.props.taskList.length) {
+      throw new Error(`Cannot remove task at index ${index}.`);
+    }
+    this.props.taskList.splice(index, 1);
+    return this;
+  }
+
+  // Remise à jour du timer du pomodoro actif - Incrémentation du temps écoulé
+  tick(): Workday {
+    const task = getActiveTask(this.taskList);
+    const taskIndex = getActiveTaskIndex(this.taskList);
+
+    if (!task) {
+      throw new Error('No active task found');
+    }
+
+    const pomodoroIndex = getActivePomodoroIndex(task);
+
+    if (pomodoroIndex === -1) {
+      throw new Error('No active pomodoro found');
+    }
+    // Incrémentation du temps écoulé du pomodoro actif de la tâche courante
+    this.taskList[taskIndex].pomodoroList[pomodoroIndex]++;
+    // Mise à jour de l'emoji de statut de la tâche courante
+    this.taskList[taskIndex].statusEmoji = getTaskEmojiStatus(
+      this.taskList[taskIndex]
+    );
+
+    return this;
+  }
+
+  // TODO: Extract following methods of Task into a Value Object.
+
+  //** Value Objects **//
+
+  // Vérification de la complétude d'une tâche
+  isTaskCompleted(task: Task): boolean {
+    if (this.isGetThingsDone(task)) {
+      return task.status === 'Done';
+    }
+
+    // Hit the target task
+    return task.pomodoroList.every((pomodoro) =>
+      this.isPomodoroCompleted(pomodoro)
+    );
+  }
+
+  // Vérification si une tâche est de type 'Get things done'
+  isGetThingsDone(task: Task): boolean {
+    return task.type === 'Get things done';
+  }
+
+  // Vérification de la complétude d'un pomodoro
+  isPomodoroCompleted(pomodoro: number): boolean {
+    return pomodoro === Workday.MAX_POMODORO_DURATION_IN_SEC;
+  }
+
+  // Récupération d'une tâche vide par défaut
+  static getEmptyTask(): Task {
+    return {
+      type: 'Hit the target',
+      title: 'Nouvelle tâche',
+      status: 'Not started',
+      pomodoroCount: 1,
+      pomodoroList: [0],
+      statusEmoji: '🏁',
+    };
+  }
+}

--- a/src/app/membership/workday/workday.page.component.html
+++ b/src/app/membership/workday/workday.page.component.html
@@ -1,31 +1,31 @@
 <!DOCTYPE html>
 <div class="container my-5">
-  <pre>{{ store.taskList() | json }}</pre>
+  <pre>{{ workday().taskList | json }}</pre>
   <!-- Header avec date centrée et bouton à droite -->
   <div class="row align-items-center mb-4">
     <div class="col-md-4"></div>
     <div class="col-md-4 text-center">
       <h6 class="mb-2">Working Day</h6>
       <!-- Sélection de la date - Ecoute de l'évènement 'change'-->
-      <input type="date" class="form-control" [value]="store.date()" (change)="store.updateDate($event)" [disabled]="store.isExecutionMode() || store.isWorkdayCompleted()"/>
+      <input type="date" class="form-control" [value]="workday().date" (change)="updateDate($event)" [disabled]="workday().isExecutionMode || workday().isWorkdayCompleted"/>
       <!-- Affichage de la barre de progression lorsque l'on passe en mode 'execution'-->
-      @if(store.isExecutionMode()) {
+      @if(workday().isExecutionMode) {
         <div class="d-flex flex-column align-items mt-2">
           <div class="progress w-100" data-testid="workday-progress">
           <div class="progress-bar progress-bar-striped progress-bar-animated bg-success" role="progressbar"
-            [style.width.%]="store.pomodoroProgress()" [attr.aria-valuenow]="store.pomodoroProgress()" aria-valuemin="0"
+            [style.width.%]="pomodoroProgress()" [attr.aria-valuenow]="pomodoroProgress()" aria-valuemin="0"
             aria-valuemax="100">
-            {{store.pomodoroProgress()}}%
+            {{ pomodoroProgress() }}%
             </div>
           </div>
-          <p class="text-muted small mt-2 text-center w-100">{{ store.progress() }} seconds have passed.</p>
+          <p class="text-muted small mt-2 text-center w-100">{{ progress() }} seconds have passed.</p>
         </div>
       }
     </div>
   <!-- Si une tâche est planifiée ou si on est en mode 'edit' -->
-  @if(store.hasTaskPlanned() && store.isEditMode() && !store.isWorkdayCompleted()) {
+  @if(workday().hasTaskPlanned && workday().isEditMode && !workday().isWorkdayCompleted) {
     <div class="col-md-4 text-end mt-3 mt-md-0">
-      <button class="btn btn-success rounded-pill px-4 py-2 fw-bold" (click)="store.startworkday()">
+      <button class="btn btn-success rounded-pill px-4 py-2 fw-bold" (click)="startWorkday()">
         Start the work day
       </button>
     </div>
@@ -33,7 +33,7 @@
   </div>
 
   <!-- Si aucune tâche n'est planifiée -->
-  @if(store.hasNoTaskPlanned() && store.isEditMode()) {
+  @if(workday().hasNoTaskPlanned && workday().isEditMode) {
   <div class="text-center my-5" data-testid="inbox-zero-placeholder">
     <!-- Image et texte à afficher -->
     <img src="images/productivity-planner-inbox-zero.gif" alt="Inbox zero" class="img-fluid mx-auto" />
@@ -42,7 +42,7 @@
   }
 
   <!-- Boucle sur les tâches à afficher -->
-  @for(task of store.taskList(); track $index) {
+  @for(task of workday().taskList; track $index) {
     <!--Titre de la tâche -->
     @if($index === 0) {
       <h6 class="mb-3 text-muted">Most important task</h6>
@@ -55,18 +55,18 @@
     }
 
     <!-- Affichage du composant Task-->
-    @if(store.isEditMode() && !store.isWorkdayCompleted() && !store.isTaskCompleted(task)) {
-      <app-task-field class="p-3 mb-3" [task]="task" [index]="$index" (taskUpdated)="store.updateTask($index, $event)" (taskRemoved)="store.removeTask($index)" />
+    @if(workday().isEditMode && !workday().isWorkdayCompleted && !workday().isTaskCompleted(task)) {
+      <app-task-field class="p-3 mb-3" [task]="task" [index]="$index" (taskUpdated)="updateTask($index, $event)" (taskRemoved)="removeTask($index)" />
     }
-    @if(store.isExecutionMode() || store.isWorkdayCompleted() || store.isTaskCompleted(task)) {
+    @if(workday().isExecutionMode || workday().isWorkdayCompleted || workday().isTaskCompleted(task)) {
       <app-task-readonly [task]="task" [index]="$index"/>
     }
   }
 
   <!-- Ajouter une tâche -->
   <div class="text-center">
-    @if(store.isButtonDisplayed()) {
-    <button data-testid="add-task-button" class="btn btn-link text-muted" (click)="store.addTask()">Ajouter une tâche</button>
+    @if(workday().canAddTask) {
+    <button data-testid="add-task-button" class="btn btn-link text-muted" (click)="addTask()">Ajouter une tâche</button>
     }
   </div>
 </div>

--- a/src/app/membership/workday/workday.page.component.spec.ts
+++ b/src/app/membership/workday/workday.page.component.spec.ts
@@ -81,23 +81,11 @@ describe('WorkdayPageComponent', () => {
       button.nativeElement.click();
       button.nativeElement.click();
       button.nativeElement.click();
-      button.nativeElement.click();
       fixture.detectChanges();
     });
-    it('sould hide "Add task" button', () => {
+    it('should hide "Add task" button', () => {
       const button = getAddTaskButton();
       expect(button).toBeNull();
-    });
-  });
-
-  describe('when no task is planned', () => {
-    beforeEach(() => {
-      getRemoveTaskButton(1).nativeElement.click();
-      fixture.detectChanges();
-    });
-
-    it('should display inbox zero placeholder', () => {
-      expect(getInboxZeroPlaceholder()).toBeTruthy();
     });
   });
 });

--- a/src/app/membership/workday/workday.page.component.ts
+++ b/src/app/membership/workday/workday.page.component.ts
@@ -3,6 +3,7 @@ import { WorkdayStore } from './workday.page.store';
 import { TaskFieldDumbComponent } from "./task-field/task-field.dumb.component";
 import { TaskReadonlyDumbComponent } from './task-readonly/task-readonly.dumb.component';
 import { JsonPipe } from '@angular/common';
+import { Task } from './task.model';
 
 @Component({
   changeDetection: ChangeDetectionStrategy.OnPush,
@@ -14,5 +15,28 @@ import { JsonPipe } from '@angular/common';
 
 export class WorkdayPageComponent {
   //Injection du store Workday dans le composant en lecture seule et à utiliser dans le template
-  readonly store = inject(WorkdayStore);
+  readonly #store = inject(WorkdayStore);
+  readonly workday = this.#store.workday;
+  readonly pomodoroProgress = this.#store.pomodoroProgress;
+  readonly progress = this.#store.progress;
+
+  addTask() {
+    this.#store.addTask();
+  }
+
+  updateTask(index: number, updatedTask: Task) {
+    this.#store.updateTask(index, updatedTask);
+  }
+
+  removeTask(index: number) {
+    this.#store.removeTask(index);
+  }
+
+  startWorkday() {
+    this.#store.startWorkday();
+  }
+
+  updateDate(event: Event) {
+    this.#store.updateDate(event);
+  }
 }

--- a/src/app/membership/workday/workday.page.store.ts
+++ b/src/app/membership/workday/workday.page.store.ts
@@ -1,164 +1,100 @@
+// Logique de vue et d'affichage pour la page Workday - Store de gestion d'état
+
 import { computed, DestroyRef, inject } from '@angular/core';
 import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
 import { patchState, signalStore, withComputed, withMethods, withProps, withState } from '@ngrx/signals';
 import { Subject, takeUntil, timer } from 'rxjs';
-import { MAXIMUM_POMODORO_DURATION, getActivePomodoroIndex, getActiveTask,PomodoroList, Task, TaskList, getActiveTaskIndex, getTaskEmojiStatus, isTaskCompleted } from './task.model';
+import { MAXIMUM_POMODORO_DURATION, Task } from './task.model';
+import { Workday } from '@app/core/entity/workday';
+
 
 // Contrat de structure de données pour l'objet 'WorkdayState'
 interface WorkdayState {
-  date: string;
-  taskList: TaskList;
+  workday: Workday;
   progress: number;
-  mode: 'edit' | 'execution';
 };
-
-// Description d'une constante pour une nouvelle tâche 'vide' par défaut
-const getEmptyTask = (): Task => ({
-  type: 'Hit the target',
-  title: 'Nouvelle tâche',
-  status: 'Not started',
-  pomodoroCount: 1,
-  pomodoroList: [0],
-  statusEmoji: '🏁',
-});
-
-// Définition d'une constante pour limiter à 6 le nombre de tâches par jour
-const WORKDAY_TASK_LIMIT = 6;
 
 // Démarrage du Store
 export const WorkdayStore = signalStore(
   withState<WorkdayState>({
     // Etat initial - Valeurs par défaut de l'Etat initial au démarrage
-    date: '2019-02-28',
-    taskList: [getEmptyTask()],
+    workday: Workday.createEmpty(),
     progress: 0,
-    mode: 'edit',
   }),
   // Ajout de propriétés et services personnalisés
   withProps(() => ({
     destroyRef: inject(DestroyRef),
+    // Using Subject to emit events when a pomodoro is completed
     pomodoroCompleted: new Subject<void>(), // (évènement programmatique pour indiquer qu'un pomodoro est complété)
   })),
   // Gestion de l'état dérivé si on atteint 6 tâches ou si aucune tâche n'est plannifiée
   withComputed((state) => {
-    const taskCount = computed(() => state.taskList().length);
-    const isButtonDisplayed = computed(() => taskCount() < WORKDAY_TASK_LIMIT);
-    const hasNoTaskPlanned = computed(() => taskCount() === 0);
-    const hasTaskPlanned = computed(() => taskCount() > 0);
-    const isEditMode = computed(() => state.mode() === 'edit');
-    const isExecutionMode = computed(() => state.mode() === 'execution');
+    // View - Couche affichage
     const pomodoroProgress = computed(() => {
       return Math.floor((state.progress() / MAXIMUM_POMODORO_DURATION)*100)
     });
 
     return { 
-      taskCount,
-      isButtonDisplayed,
-      hasNoTaskPlanned, 
-      hasTaskPlanned, 
-      isEditMode, 
-      isExecutionMode, 
       pomodoroProgress };
   }), 
   // Gestion des interactions de l'utilisateur à partir du template
   withMethods(({ destroyRef, pomodoroCompleted, ...store }) => ({
     // Gestion du démarrage d'une tâche - Mise à jour de la tâche courante en fonction du temps écoulé
-    startworkday() {
-      patchState(store, { mode: 'execution'});
-      console.log('Workday started!');
+    startWorkday() {
+      // Passage en mode exécution
+      patchState(store, { workday: store.workday().setExecutionMode() });
       // Démarrage d'un flux avec un Observable (méthode 'timer' de RXJS) pour gérer lancement du chronomètre (gestion du temps - Décompte des secondes écoulées)
       timer(0, 1000).pipe(takeUntil(pomodoroCompleted), takeUntilDestroyed(destroyRef)).subscribe((elapsedSeconds: number) => {
-        console.log('elapsedSeconds', elapsedSeconds);
-        
+        // Mise à jour de la progression du pomodoro dans le state
         patchState(store, { progress: elapsedSeconds });
-      
-        patchState(store, (state) => {
-          // Récupération de la tâche courante dans le tableau Workday
-          const task = getActiveTask(state.taskList);
-          // Récupération de l'index de la tâche courante dans le tableau Workday
-          const taskIndex = getActiveTaskIndex(store.taskList());
-          if(!task){
-            throw new Error('No active task found');
-          }
 
-          // Récupération de l'index du pomodoro actif de la Workday
-          const pomodoroIndex = getActivePomodoroIndex(task);
-          if(pomodoroIndex === -1) {
-            throw new Error('No active pomodoro found');
-          }
-
-          // Mise à jour et reconstruction de la tâche - Incrémentation du timer du pomodoro actif (à l'index du pomodoro actif) - Mise à jour le temps écoulé
-          
-          // Create a new pomodoro list and a new task object (immutable update)
-            const newPomodoroList = [...task.pomodoroList] as PomodoroList;
-            newPomodoroList[pomodoroIndex] = elapsedSeconds;
-
-            const updatedTask: Task = {
-              ...task,
-              pomodoroList: newPomodoroList,
-              statusEmoji: getTaskEmojiStatus({
-                ...task,
-                pomodoroList: newPomodoroList,
-              }),
-            };
-
-          // Mise à jour de l'emoji de statut de la tâche
-          
-
-          // Récupération de la liste des tâches mise à jour à partir du store
-          const taskList: TaskList = store
-          .taskList()
-          // On remplace dans la taskList la tâche courante par la tâche mise à jour 
-          .toSpliced(taskIndex, 1, updatedTask);
-       
-          // Patch de la liste des tâches mise à jour dans le store
-          return { taskList };
-        });
-        
-        // Gestion de la complétude des états ...
-
-        // Si les secondes écoulées sont égales à la durée maximale d'un pomodoro)
-        if(elapsedSeconds === MAXIMUM_POMODORO_DURATION) {
-          // Alors on se désabonne ... (déclaration d'un 'subject') - N.B. Le timer peut s'arrêter pour 3 raisons : 1. On quitte le composant (il est détruit) - 2. l'utilisateur à cliqué sur 'completed pomodoro' (évènement utilisateur stocké dans un 'subject') - 3. Evènement programmatique (Subject) déclenché lorsque la durée du pomodoro écoulée):
+        // Gestion de la complétude des pomodoros ... 
+        // Si les secondes écoulées sont égales à la durée maximale d'un pomodoro
+        if (elapsedSeconds === Workday.MAX_POMODORO_DURATION_IN_SEC) {
+          // Notification de la complétude du pomodoro via l'évènement programmatique
           pomodoroCompleted.next();
-          // On repasse en mode 'edit' pour permettre à l'utilisateur de valider le pomodoro complété et on réinitiaise le compteur de progression
-          patchState(store, { mode: 'edit', progress: 0 });
+          // Réinitialisation du compteur de progression
+          patchState(store, ({ workday }) => ({
+              workday: workday.setEditMode(),
+              progress: 0,
+          }));
+          return;
         }
 
+        // Mise à jour de l'état de la journée de travail (incrémentation du timer du pomodoro actif)
+        patchState(store, ({ workday }) => {
+            return { workday: workday.tick() };
+        }); 
       });
     },
-    // Gestion de la vérification de l'achèvement de la journée de travail
-    isWorkdayCompleted(): boolean {
-      return store.taskList().every((task) => {
-        return isTaskCompleted(task);
-      });
-    },
-    // Gestion de la vérification de l'achèvement d'une tâche
-    isTaskCompleted(task: Task): boolean {
-      return isTaskCompleted(task);
-    },
-
     // Gestion de l'ajout d'une nouvelle tâche - Réponse à l'évènement clic
     addTask() {
       // Patch de la nouvelle tâche dans le state (modification du state de manière immutable)
-      patchState(store, (state) => ({ taskList: [...state.taskList, getEmptyTask()] }))
+      patchState(store, ({ workday }) => ({ workday: workday.addEmptyTask() }));
     },
     // Gestion de la suppression d'une tâche ajoutée - On conserve les tâches n'ayant pas l'index courant
-    removeTask($index: number) {
+    removeTask(index: number) {
       // Patch de la nouvelle tâche dans le state (modification du state de manière immutable)
-      patchState(store, (state) => ({ taskList: state.taskList.toSpliced($index, 1) }))
+      patchState(store, ({workday}) => ({ workday: workday.removeTask(index) }));
     },
     // Gestion de la mise à jour de la date
     updateDate(event: Event) {
       const date = (event.target as HTMLInputElement).value;
-      patchState(store, () => ({ date }));
+      patchState(store, ({ workday }) => ({
+        workday: workday.createEmptyAtDate(date),
+      }));
     },
     // Gestion de la mise à jour de la tâche
     updateTask(index: number, updatedTask: Task) {
-      patchState(store, (state) => {const taskList: TaskList = state.taskList.toSpliced(index, 1, updatedTask);
-        return { taskList };
-      });
-     },
+      patchState(store, ({ workday }) => ({
+        workday: workday.updateTask(index, updatedTask),
+      }));
+    },
+    // Gestion de la sauvegarde de la journée de travail
+    /* saveWorkday(workday: Workday): Observable<void> {
+      console.log('Workday saved!', workday);
+      return of(undefined);
+    } */
   }))
 );
 


### PR DESCRIPTION
## What this PR do ?

Preparatory work for TASK-39, which involves backing up a Workday instance to the backend.
We create the Workday entity, based on the Lego Driven Development "Entity" building block (entity.class.ts).

Next, we move the business logic to this Workday entity and refactor the State Management to streamline it.

The store is now marked as private at the WorkdayComponent level to reinforce the separation between layers since the introduction of the Workday entity.

The code work like before.